### PR TITLE
Arrumando chamadas para /postagens

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,5 +42,6 @@ module.exports = {
     'no-param-reassign': 'off',
     'no-debugger': 'off',
     'no-nested-ternary': 'off',
+    'react/forbid-prop-types': 'warn',
   },
 };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "history": "^5.0.0",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.21",
+    "moment": "^2.29.1",
     "polished": "^4.1.1",
     "prettier": "^2.2.1",
     "prop-types": "^15.7.2",

--- a/src/components/elements/Feed/index.js
+++ b/src/components/elements/Feed/index.js
@@ -10,6 +10,7 @@ const Feed = ({
   user,
   avatar,
   canVerifyPost,
+  fetchComments,
   onCreateComment,
   onAddSelo,
 } = {}) => {
@@ -30,6 +31,7 @@ const Feed = ({
           user={user}
           avatar={avatar}
           verifiable={canVerifyPost}
+          fetchComments={fetchComments}
           onCreateComment={onCreateComment}
           onAddSelo={onAddSelo}
         />
@@ -44,6 +46,7 @@ Feed.defaultProps = {
   user: '????',
   avatar: 'https://bit.ly/dan-abramov',
   canVerifyPost: false,
+  fetchComments: async () => [],
   onCreateComment: () => {},
   onAddSelo: () => {},
 };
@@ -56,12 +59,13 @@ Feed.propTypes = {
         id: PropTypes.string.isRequired,
         name: PropTypes.string.isRequired,
       },
-      dateTime: PropTypes.string.isRequired,
+      dateTime: PropTypes.object.isRequired, // TODO: invoke moment object type
     }),
   ),
   user: PropTypes.string,
   avatar: PropTypes.string,
   canVerifyPost: PropTypes.bool,
+  fetchComments: PropTypes.func,
   onCreateComment: PropTypes.func,
   onAddSelo: PropTypes.func,
 };

--- a/src/domain/comentarios/getAll.js
+++ b/src/domain/comentarios/getAll.js
@@ -1,4 +1,5 @@
 import {get, has, isEmpty, isNil} from 'lodash';
+import moment from 'moment';
 
 import api from '../../services/api';
 
@@ -22,7 +23,7 @@ export default async function getAll(token) {
       avatar: '<API NÃO ESTÁ ENVIANDO>',
     },
     post: get(comentario, 'postagem'),
-    dateTime: '<API NÃO ESTÁ ENVIANDO>',
+    dateTime: moment(get(comentario, 'data')),
     body: get(comentario, 'texto'),
   }));
 }

--- a/src/domain/postagens/get.js
+++ b/src/domain/postagens/get.js
@@ -1,0 +1,54 @@
+import {flatten, get, has, isEmpty, isNil, isString} from 'lodash';
+import moment from 'moment';
+import stringify from '../../utils/stringify';
+
+import api from '../../services/api';
+
+// eslint-disable-next-line func-names
+export default async function (token, id) {
+  if (isNil(token) || isEmpty(token))
+    throw new Error('Token não foi informado');
+
+  if (isNil(id) || (isEmpty(id) && isString(id)))
+    throw new Error('Id da postagem não foi informado');
+
+  const post = await api.get(`/postagens/${id}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!has(post, 'data')) return null;
+
+  return {
+    id: get(post, 'data.id'),
+    title: get(post, 'data.titulo'),
+    description: get(post, 'data.texto'),
+    category: {
+      id: get(post, 'data.categoria'),
+      name: '<API NÃO ESTÁ ENVIANDO>',
+    },
+    neighborhood: {
+      id: '<API NÃO ESTÁ ENVIANDO>',
+      name: '<API NÃO ESTÁ ENVIANDO>',
+    },
+    author: {
+      id: get(post, 'data.criador.id'),
+      name: get(post, 'data.criador.name'),
+      avatar: '<API NÃO ESTÁ ENVIANDO>',
+    },
+    dateTime: moment(get(post, 'data.data')),
+    verified: get(post, 'data.selo'),
+    comments: get(post, 'data.comentarios', []).map((comentario) => ({
+      id: '<API NÃO ESTÁ ENVIANDO>',
+      author: {
+        id: get(comentario, 'criador.id'),
+        name: get(comentario, 'criador.name'),
+        avatar: '<API NÃO ESTÁ ENVIANDO>',
+      },
+      post: get(comentario, 'postagem'),
+      dateTime: moment(get(comentario, 'data')),
+      body: get(comentario, 'texto'),
+    })),
+  };
+}

--- a/src/domain/postagens/getAll.js
+++ b/src/domain/postagens/getAll.js
@@ -1,4 +1,5 @@
 import {flatten, get, has, isEmpty, isNil} from 'lodash';
+import moment from 'moment';
 import stringify from '../../utils/stringify';
 
 import api from '../../services/api';
@@ -41,8 +42,8 @@ export default async function getAll(
       name: get(post, 'criador'),
       avatar: '<API NÃO ESTÁ ENVIANDO>',
     },
-    dateTime: '<API NAO ESTÁ ENVIANDO>',
+    dateTime: moment(get(post, 'data')),
     verified: get(post, 'selo'),
-    comments: [], // '<API NAO ESTÁ ENVIANDO>'
+    comments: get(post, 'comentarios', 0),
   }));
 }

--- a/src/domain/postagens/index.js
+++ b/src/domain/postagens/index.js
@@ -1,3 +1,4 @@
+export {default as get} from './get';
 export {default as getAll} from './getAll';
 export {default as create} from './create';
 export {default as addSelo} from './addSelo';

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
+import moment from 'moment';
+import 'moment/locale/pt-br'; // without this line it didn't work
 import App from './App';
+
+moment.locale('pt-br');
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -10656,6 +10656,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+moment@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
closes #98 

Algumas chamadas para /postagens foram modificadas (com o pr [#35](https://github.com/CodelabUnifesp/PlaSMeDIS-API/pull/35) da api), então esse pr é pra adequar o feed à essas modificações.

O único impacto mesmo é que agora o feed mostra a data de criação das postagens/comentários e mostra o nome do autor do comentário.

Algo que a gente vai ter que fazer no futuro é criar uma outra camada de abstração. Por exemplo, existe uma nova funcao no domain para /postagens/:id_postagem (/domain/postagens/get.js), e ela repete muito do código que é usado em /domain/postagens/getAll.js (em especial as linhas de código para converter o que a api envia -> um modelo "universal" dentro do front).