### PR TITLE
[Mobile] Categorias (Saúde, etc...) não aparecem

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ function App() {
   return (
     <ChakraProvider theme={theme}>
       <AuthProvider>
-        <Box className="appContainer" bg={{base: 'white', lg: 'light.50'}}>
+        <Box className="appContainer" bg={{base: '#F0F6F8', lg: 'light.50'}}>
           <Routes />
         </Box>
       </AuthProvider>

--- a/src/components/elements/Header/index.js
+++ b/src/components/elements/Header/index.js
@@ -12,8 +12,7 @@ const Header = ({children, open, onMenu} = {}) => (
   <>
     <Wrapper
       bg={{base: 'primary.600', lg: 'white'}}
-      color={{base: 'white', lg: 'primary.600'}}
-      style={open ? {boxShadow: 'none'} : {}}>
+      color={{base: 'white', lg: 'primary.600'}}>
       <Container className="TETSEEEE" py={4} px={{base: 6, lg: 4}}>
         <Text fontWeight="bold" fontSize="xl">
           IBEApp

--- a/src/components/elements/Header/styles.js
+++ b/src/components/elements/Header/styles.js
@@ -9,7 +9,7 @@ export const Wrapper = styled(Box)`
     position: sticky;
     top: 0px;
     z-index: 2;
-    boxshadow: ${(props) => (props.open ? 'none' : {})};
+    box-shadow: none;
   `};
 `;
 

--- a/src/components/layouts/default/index.js
+++ b/src/components/layouts/default/index.js
@@ -26,7 +26,8 @@ const Default = ({children} = {}) => {
               bg={{base: 'primary.600', lg: 'white'}}
               color={{base: 'white', lg: 'primary.600'}}
               zIndex={9}
-              boxShadow="0px 0.25rem 0.25rem 0px rgba(0, 0, 0, 0.25)">
+              // boxShadow="0px 0.25rem 0.25rem 0px rgba(0, 0, 0, 0.25)"
+            >
               <Box pb={6} flexBasis={{base: '100%', lg: 'none'}}>
                 <Stack
                   spacing={1}

--- a/src/screens/Home/index.js
+++ b/src/screens/Home/index.js
@@ -36,7 +36,7 @@ import * as Comentarios from '../../domain/comentarios';
 function Home() {
   const tabs = useBreakpointValue(
     {
-      base: ['Feed', 'Recomendados'],
+      base: ['Feed', 'Recomendados', 'Saúde', 'Trocas', 'Cultura e Lazer'],
       lg: ['Feed', 'Recomendados', 'Saúde', 'Trocas', 'Cultura e Lazer'],
     },
     'base',
@@ -128,7 +128,12 @@ function Home() {
           my={{base: 0, lg: 4}}>
           <TabList
             color={{base: 'light.300', lg: '#333'}}
-            bg={{base: 'primary.600', lg: 'transparent'}}>
+            bg={{base: 'primary.600', lg: 'transparent'}}
+            maxWidth="100vw"
+            overflowX="scroll"
+            style={{
+              scrollbarWidth: 'thin',
+            }}>
             {tabs.map((tabName, index) => (
               <Tab
                 key={index}


### PR DESCRIPTION
closes #130, #131

Adicionando as abas para as categorias de postagem no mobile (com scroll horizontal). Também removendo sombra excessiva acima das tabs/abaixo do header.

![bugfix_130](https://user-images.githubusercontent.com/12667933/138767517-1e9a979a-4875-4d46-859f-0b8efb1fb40c.gif)